### PR TITLE
Keep port of canonical URL when HTTPS is off

### DIFF
--- a/concrete/src/Url/Resolver/CanonicalUrlResolver.php
+++ b/concrete/src/Url/Resolver/CanonicalUrlResolver.php
@@ -91,6 +91,9 @@ class CanonicalUrlResolver implements UrlResolverInterface
                     }
                 }
             }
+            elseif (intval($canonical->getPort()->get()) > 0) {
+                $url = $url->setPort($canonical->getPort());
+            }
         }
 
         if ($relative_path = $this->app['app_relative_path']) {


### PR DESCRIPTION
If the canonical URL is http (not https) and it has a non-standard port, this port gets lost: let's keep it
